### PR TITLE
Added -D_DARWIN_C_SOURCE=1 to compiler flags to ensure non-default exten...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ WARN = -Wall -Wextra -pedantic
 # both C99 _and_ POSIX (for the BSD sockets API).
 CDEFS += -D_POSIX_C_SOURCE=1
 
+# This is necessary for OSX Clang to define snprintf,
+# since it is disabled in stdio when POSIX compliance
+# is turned on.
+CDEFS += -D_DARWIN_C_SOURCE=1
+
 CFLAGS += -std=c99 -g ${WARN} ${CDEFS} ${OPTIMIZE}
 #LDFLAGS +=
 


### PR DESCRIPTION
I found this solution which eliminates the build warning when built on OSX Clang stating that snprintf is not defined.

By default, when POSIX compliance is enabled, snprintf, and some other extensions are not available in the default stdio inclusion. Adding this flag re-enables these extensions, in addition to the POSIX requirements.

I stumbled on this patch in [this thread](http://sourceforge.net/p/gphoto/bugs/935/)
